### PR TITLE
add Vue.js Israel May meetup to calendar & to meetups list

### DIFF
--- a/src/.vuepress/data/2019.json
+++ b/src/.vuepress/data/2019.json
@@ -715,6 +715,17 @@
       "name": "Lightning Talks",
       "eventLink": "https://www.meetup.com/vuejsfrankfurt/events/255460193/",
       "type": "meetup"
+    },
+    {
+      "date": "13rd",
+      "time": "at 6:30PM",
+      "startDate": "2019-05-13",
+      "endDate": "2019-05-13",
+      "organiser": "Vue.js Israel",
+      "organiserLink": "https://vuejsisrael.com/",
+      "name": "May the Vue be with you - New beginning 🎉🎉",
+      "eventLink": "https://www.meetup.com/vue-js/events/259354986/",
+      "type": "meetup"
     }
   ],
   "November": [

--- a/src/meetups/README.md
+++ b/src/meetups/README.md
@@ -115,7 +115,8 @@ And if you haven't heard of it, check out [VuePeople](https://vuepeople.org) to 
 
 ### Israel
 
-- Sderot - [GoCode in Sderot](https://www.meetup.com/GoCode-in-Sderot/)
+- Tel Aviv - [VueJS Israel](https://www.vuejsisrael.com)
+- Sderot - [GoCode in Sderot](https://www.meetup.com/vue-js/)
 
 ### Italy
 


### PR DESCRIPTION
1. Add VueJS Israel to list of meetup groups.
2. Add VueJS Israel May meetup to calendar of upcoming meetups for 2019