### PR TITLE
Updated VueJs Columbus Meetup Url

### DIFF
--- a/src/meetups/README.md
+++ b/src/meetups/README.md
@@ -259,7 +259,7 @@ The following list prioritizes users' ability to quickly locate the regions they
   - Raleigh - [Vue Raleigh](https://www.meetup.com/Vue-Raleigh/)
 - Ohio
   - Cleveland - [Cleveland VueJS](https://www.meetup.com/Cleveland-VueJS/)
-  - Columbus - [Vue Columbus](https://www.meetup.com/Vue-Columbus/)
+  - Columbus - [Vue Columbus](https://www.javascriptandfriends.com/communityevents)
 - Oregon
   - Portland - [Portland Vue.js Meetup](https://www.meetup.com/Portland-Vue-js-Meetup)
 - Pennsylvania
@@ -318,3 +318,4 @@ The following list prioritizes users' ability to quickly locate the regions they
 ## Remote
 
 - ThisDot - [VueMeetup](https://www.vuemeetup.com/)
+- JavaScript and Friends - [VueEvents](https://www.javascriptandfriends.com/communityevents)


### PR DESCRIPTION
As organizers we have closed meetup.com page since we did not had any sponsors for subscription. We are moving the meetup under JavaScript and Friends and allowing attendees to attend in-person as well as remote. The Community Events Page will have details to RSVP every month.