### PR TITLE
Fix icon size

### DIFF
--- a/src/.vuepress/components/EventItem.vue
+++ b/src/.vuepress/components/EventItem.vue
@@ -104,7 +104,7 @@ export default {
 	float: right;
 }
 
-.content:not(.custom) .event__icon {
+.event__info img.event__icon {
 	max-width: 20px;
 	vertical-align: middle;
 }


### PR DESCRIPTION
Fixes #99 

`.content` is not in the DOM on this page.

Had to increase specificity of the selector because it was competing with

```css
.theme-default-content:not(.custom) img {
    max-width: 100%;
}
```

Selector used is simplest/lowest specificity possible without having to rewrite other styles.

Did not run locally.