### PR TITLE
Fix/Update meetup and events lists

### DIFF
--- a/src/events/README.md
+++ b/src/events/README.md
@@ -4,7 +4,7 @@ sidebar: auto
 
 # Upcoming Events
 
-## Conferences
+## Events
 
 ### [VueDC](https://www.meetup.com/Vue-DC/)
 

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -6,20 +6,65 @@ sidebar: auto
 
 ## Conferences
 
-### [VueJS Amsterdam](https://vuejs.amsterdam/)
+### [VueDC](https://www.meetup.com/Vue-DC/)
 
-- **Dates:** February 20th - 21th, 2020
-- **Location:** Amsterdam, The Netherlands
+- **Dates:** May 13th, 2020
+- **Location:** Online
 
-### [VueConfUS](https://vueconf.us/)
+### [Stuttgart Vue.js Meetup](https://www.meetup.com/Stuttgart-Vue-js-Meetup/)
 
-- **Dates:** March 2nd - 4th, 2020
-- **Location:** Austin, Texas, USA
+- **Dates:** May 14th, 2020
+- **Location:** Online
 
-### [Vue Vixens Day](https://vvdayus.vuevixens.org/)
+### [Vue.js Vienna Meetup](https://www.meetup.com/vuejsvienna/)
 
-- **Dates:** March 5th, 2020
-- **Location:** Austin, Texas, USA
+- **Dates:** May 19th, 2020
+- **Location:** Online
+
+### [Vue.js MN Meetup](https://www.meetup.com/mpls-vue/)
+
+- **Dates:** May 19th, 2020
+- **Location:** Online
+
+### [Austin Vue.js Meetup](https://www.meetup.com/The-Austin-Vue-js-Meetup/)
+
+- **Dates:** May 19th, 2020
+- **Location:** Online
+
+### [Dallas Vue Meetup](https://www.meetup.com/Dallas-Vue-Meetup/)
+
+- **Dates:** May 19th, 2020
+- **Location:** Online
+
+### [Vue.js Finland Meetup](https://www.meetup.com/vuejs-finland/)
+
+- **Dates:** May 20th, 2020
+- **Location:** Online
+
+### [VueJS Israel](https://www.meetup.com/vue-js/)
+
+- **Dates:** May 20th, 2020
+- **Location:** Ha-Umanim St 12 · Tel Aviv-Yafo
+
+### [ThisDot - VueMeetup](https://www.vuemeetup.com/#/)
+
+- **Dates:** May 21st, 2020
+- **Location:** Online
+
+### [Seattle Vue.js](https://www.meetup.com/SeattleVueJS/)
+
+- **Dates:** May 27th, 2020
+- **Location:** Online
+
+### [v-kansai Vue.js/Nuxt.js meetup](https://vuekansai.connpass.com/)
+
+- **Dates:** June 13th, 2020
+- **Location:** Online
+
+### [World Vue Collaborative Meetup](https://worldvue.io/)
+
+- **Dates:** June 30th, 2020
+- **Location:** Online
 
 ## Meetups
 

--- a/src/meetups/README.md
+++ b/src/meetups/README.md
@@ -51,7 +51,6 @@ The following list prioritizes users' ability to quickly locate the regions they
 ### Mainland China
 
 - Beijing - [Vue.js Beijing](https://www.vuebeijing.io/)
-- Shanghai - [VueJS Shanghai](http://sh.vuejs.city/)
 
 ### Philippines
 
@@ -85,7 +84,6 @@ The following list prioritizes users' ability to quickly locate the regions they
 
 ### Victoria
 
-- Melbourne - [Vuers in Melbourne](https://meetup.com/Vuers-in-Melbourne)
 - Melbourne - [Melbourne Vue.js Meetup](https://meetup.com/vuejs-melbourne)
 
 ## Central America
@@ -220,11 +218,6 @@ The following list prioritizes users' ability to quickly locate the regions they
 
 - Montreal - [Montreal Vue.js](https://www.meetup.com/Vue-js-Montreal/)
 - Toronto - [Vue Toronto](https://www.meetup.com/Vue-Toronto/)
-- Vancouver - [Vancity Vue.js](https://www.meetup.com/Vancity-Vue-js/)
-
-### Mexico
-
-- Monterrey - [Vue.js](https://meetup.com/Vue-js)
 
 ### United States
 
@@ -250,7 +243,6 @@ The following list prioritizes users' ability to quickly locate the regions they
   - Boston - [Boston Vue.js](https://www.meetup.com/Boston-Vue-js/)
 - Michigan
   - Detroit - [Vuetroit](https://www.meetup.com/Vuetroit/)
-  - Ann Arbor - [Michigan Vue](https://www.meetup.com/Michigan-Vue/)
 - Minnesota
   - Twin Cities - [Mpls Vue.js Meetup](https://www.meetup.com/mpls-vue)
 - Missouri
@@ -297,10 +289,10 @@ The following list prioritizes users' ability to quickly locate the regions they
 ### Brazil
 
 - Belo Horizonte - [Vue.js @ Belo Horizonte](https://meetup.com/Vuejs-at-BH)
-- Curitiba - [Vue Curitiba](https://www.meetup.com/pt-BR/Vue-Curitiba/)
+- Curitiba - [Vue Curitiba](https://www.facebook.com/Vuejs-Curitiba-286947468925534)
 - Espírito Santo - [Vue.js Vix](https://www.meetup.com/pt-BR/Vue-js-in-Vix/)
 - Florianópolis - [Vue.js Floripa](https://meetup.com/floripa-vuejs)
-- Juazeiro - [Vue Sertão](https://www.meetup.com/pt-BR/vuejs-sertao/)
+- Juazeiro - [Vue Sertão](https://www.facebook.com/pages/category/Sports-Event/Vue-sert%C3%A3o-324971338132377/)
 - Pará - [Vue.js Norte](https://www.meetup.com/pt-BR/Vue-js-Norte)
 - Porto Alegre - [Vue.js Porto Alegre](https://www.meetup.com/Meetup-de-Vue-js-Porto-Alegre/)
 - Rio de Janeiro - [Vue.js in Rio](https://meetup.com/Vue-js-in-Rio)


### PR DESCRIPTION
@bencodezen I looked over the list of events as promised, and did the following:
1. Removed all dead meetups with dead links, except if a quick google search provided me with a new link to the meetup group
2. Removed past events from `upcoming events` and added all upcoming ones that I could find

I have not find any missing meetup groups yet, but will add any as I come across new ones.