### PR TITLE
Add Vue.js London 2021

### DIFF
--- a/src/conferences/README.md
+++ b/src/conferences/README.md
@@ -8,7 +8,10 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 
 ## Upcoming
 
-N/A
+### [Vue London](https://vuejs.london/)
+
+- Dates: October 20th - 21st, 2021
+- Location: London, United Kingdom + Remote (hybrid)
 
 ## Past
 


### PR DESCRIPTION
Hey,

We're announcing the Vue.js London 2021 conference today, happy to get back to events as vaccination efforts are going well in UK