### PR TITLE
vuejs.de Conf: Remove cfp and changed the conference date

### DIFF
--- a/src/call-for-proposals/README.md
+++ b/src/call-for-proposals/README.md
@@ -12,11 +12,6 @@ This section is intended to provide a single source of truth for Vue.js develope
 
 ## Current CFPs
 
-### [Vuejs.de Conf](https://conf.vuejs.de/call-for-paper)
-
-- Dates: September 22nd, 2022
-- Location: Berlin, Germany
-
 ### [Vue London](https://forms.gle/MyHUPCyiiNUj9Aht8)
 
 - Dates: October 20th - 21st, 2021

--- a/src/conferences/README.md
+++ b/src/conferences/README.md
@@ -12,7 +12,7 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 
 #### [Vuejs.de Conf](https://conf.vuejs.de/)
 
-- **Dates:** September 22nd, 2022
+- **Dates:** October 5th, 2022
 - **Location:** Berlin, Germany
 
 ## Past


### PR DESCRIPTION
The CFP of our vuejs.de Conf is closed, and we postponed the event to October.