### PR TITLE
Update the date of the Vue.js Nation event and add under upcoming events

### DIFF
--- a/src/conferences/README.md
+++ b/src/conferences/README.md
@@ -8,6 +8,13 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 
 ## Upcoming
 
+### 2023
+
+#### [Vue.js Nation](https://vuejsnation.com/)
+
+- **Dates:** January 25-26th, 2023
+- **Location:** [Remote Conference] (https://vuejsnation.com/)
+
 ### 2022
 
 #### [Vue.js Forge](https://vuejsforge.com/)
@@ -46,11 +53,6 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 
 - **Dates:** November 16-17th, 2022
 - **Location:** [Remote Conference] (https://nuxtnation.com/)
-
-#### [Vue.js Nation](https://vuejsnation.com/)
-
-- **Dates:** January 26-27th, 2023
-- **Location:** [Remote Conference] (https://vuejsnation.com/)
 
 
 ## Past

--- a/src/conferences/README.md
+++ b/src/conferences/README.md
@@ -37,6 +37,22 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 - **Dates:** November 22-23rd, 2021
 - **Location:** [Remote Conference](https://www.vuetoronto.com/)
 
+#### [Vue.js Forge](https://vuejsforge.com/)
+
+- **Dates:** August 30-31st, 2022
+- **Location:** [Remote Conference] (https://vuejsforge.com/)
+
+#### [Nuxt Nation](https://nuxtnation.com/)
+
+- **Dates:** November 16-17th, 2022
+- **Location:** [Remote Conference] (https://nuxtnation.com/)
+
+#### [Vue.js Nation](https://vuejsnation.com/)
+
+- **Dates:** January 26-27th, 2023
+- **Location:** [Remote Conference] (https://vuejsnation.com/)
+
+
 ## Past
 
 ### 2020


### PR DESCRIPTION
The date of the Vue.js Nation event has been changed, I have updated it and moved it to the 2023 upcoming events. Thank you!