### PR TITLE
docs: add Vue Fes Japan 2026 details to the events list

### DIFF
--- a/src/conferences/README.md
+++ b/src/conferences/README.md
@@ -27,6 +27,11 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 - **Dates:** May 22nd, 2026
 - **Location:** Madrid, Spain
 
+### [Vue Fes Japan 2026](https://vuefes.jp/2026/en)
+
+- **Dates:** October 24th, 2026
+- **Location:** Tokyo, Japan
+
 ## Past
 
 ### 2025

--- a/src/conferences/README.md
+++ b/src/conferences/README.md
@@ -15,11 +15,6 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 - **Dates:** September 23rd, 2025
 - **Location:** Prague, Czech Republic
 
-#### [Vue Fes Japan 2025](https://vuefes.jp/2025/)
-
-- **Dates:** October 25th, 2025
-- **Location:** Tokyo, Japan
-
 ### 2026
 
 #### [MadVue](https://madvue.es/)
@@ -27,7 +22,7 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 - **Dates:** May 22nd, 2026
 - **Location:** Madrid, Spain
 
-### [Vue Fes Japan 2026](https://vuefes.jp/2026/en)
+#### [Vue Fes Japan 2026](https://vuefes.jp/2026/en)
 
 - **Dates:** October 24th, 2026
 - **Location:** Tokyo, Japan
@@ -55,6 +50,11 @@ Here you will find conferences that have a specific focus on Vue.js. This means 
 
 - **Dates:** July 12th, 2025
 - **Location:** 中国·深圳 / Shenzhen, China
+
+### [Vue Fes Japan 2025](https://vuefes.jp/2025/)
+
+- **Dates:** October 25th, 2025
+- **Location:** Tokyo, Japan
 
 ### 2024
 

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -11,11 +11,6 @@ sidebar: auto
 - **Dates:** September 23rd, 2025
 - **Location:** Prague, Czech Republic
 
-### [Vue Fes Japan 2025](https://vuefes.jp/2025/)
-
-- **Dates:** October 25th, 2025
-- **Location:** Tokyo, Japan
-
 ### [MadVue](https://madvue.es/)
 
 - **Dates:** May 22nd, 2026
@@ -39,15 +34,15 @@ Looking for in-person training? Look no further. You will be able to find worksh
 - Dates: Open always
 - Location: Online
 
-### [Vue Fes Japan 2025](https://vuefes.jp/2025/)
-
-- **Dates:** October 25th, 2025
-- **Location:** Tokyo, Japan
-
 ### [MadVue 2026](https://madvue.es/cfp/)
 
 - **Dates:** May 22nd, 2026
 - **Location:** Madrid, Spain
+
+### [Vue Fes Japan 2026](https://vuefes.jp/2026/en)
+
+- **Dates:** Stay tuned
+- **Location:** Tokyo, Japan
 
 ---
 

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -21,6 +21,11 @@ sidebar: auto
 - **Dates:** May 22nd, 2026
 - **Location:** Madrid, Spain
 
+### [Vue Fes Japan 2026](https://vuefes.jp/2026/en)
+
+- **Dates:** October 24th, 2026
+- **Location:** Tokyo, Japan
+
 ## Workshops
 
 Looking for in-person training? Look no further. You will be able to find workshops around the world by core team members and official community partners here.


### PR DESCRIPTION
Nice to meet you. I am a member of the core organizing team for Vue Fes Japan 2026.

As we are preparing to host Vue Fes Japan again this year, we would be very grateful if you could consider featuring our event on your platform.
https://vuefes.jp/2026/en
Thank you very much for your time and kind consideration.