### PR TITLE
docs(cfp): update Vue Fes Japan 2026 CFP details and date

### DIFF
--- a/src/call-for-proposals/README.md
+++ b/src/call-for-proposals/README.md
@@ -12,9 +12,9 @@ This section is intended to provide a single source of truth for Vue.js develope
 
 ## Current CFPs
 
-### [Vue Fes Japan 2025](https://vuefes.jp/2025/)
+### [Vue Fes Japan 2026](https://vuefes.jp/2026/en#cfp)
 
-- **Dates:** October 25th, 2025
+- **Dates:** October 24th, 2026
 - **Location:** Tokyo, Japan
 
 ### [MadVue 2026](https://madvue.es/cfp/)

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -39,9 +39,9 @@ Looking for in-person training? Look no further. You will be able to find worksh
 - **Dates:** May 22nd, 2026
 - **Location:** Madrid, Spain
 
-### [Vue Fes Japan 2026](https://vuefes.jp/2026/en)
+### [Vue Fes Japan 2026](https://vuefes.jp/2026/en#cfp)
 
-- **Dates:** Stay tuned
+- **Dates:** October 24th, 2026
 - **Location:** Tokyo, Japan
 
 ---


### PR DESCRIPTION
The Vue Fes Japan 2026 CFP is now open, and the CFP page has been updated to reflect this year's entry details.

https://vuefes.jp/2026/en#cfp